### PR TITLE
Use 1.54.0 as default Sass version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Optionally, configure it for your needs (default values shown):
 ```groovy
 sass {
   // dart-sass version to use:
-  version = '1.49.9'
+  version = '1.54.0'
 
   // Directory where to install dart-sass:
   directory = file ("${rootDir}/.gradle/sass")

--- a/src/main/java/io/miret/etienne/gradle/sass/SassGradlePluginExtension.java
+++ b/src/main/java/io/miret/etienne/gradle/sass/SassGradlePluginExtension.java
@@ -19,7 +19,7 @@ public class SassGradlePluginExtension {
   private boolean autoCopy;
 
   public SassGradlePluginExtension (Project project) {
-    this.version = "1.49.9";
+    this.version = "1.54.0";
     this.directory = project.getRootDir ()
         .toPath ()
         .resolve (".gradle/sass")


### PR DESCRIPTION
Since https://github.com/EtienneMiret/sass-gradle-plugin/pull/20 the default behavior of this plugin on M1 mac is to try downloading Sass 1.49.9 for ARM64 which does not exist, users need to specify a newer version that does support ARM (at least 1.49.11). Bumping Sass version makes sure this plugin is not broken by default for M1 users.