### PR TITLE
Allow users to specify custom entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ compileSass {
   // Source directory containing sass to compile:
   sourceDir = project.file ("${projectDir}/src/main/sass")
 
+  // Specify entry points for sass compilation
+  // (default is to compile all .scss files in sourceDir
+  // and output a .css file with the same name for each)
+  // Those paths are relative to sourceDir and outputDir/destPath respectively.
+  entryPoint "main.scss", "styles.css"
+  entryPoint "errors.scss", "errors.css"
+
   // Add a directory to sass load path (default is empty):
   loadPath project.file ('sass-lib')
   loadPath project.file ('/var/lib/compass')

--- a/examples/custom-paths/build.gradle
+++ b/examples/custom-paths/build.gradle
@@ -5,8 +5,8 @@
  *  - set `destPath` to the desired destination path relative to the war root,
  *  - apply the war plugin.
  *
- * In this configuration, the `style.scss` file gets compiled to a `style.css`
- * and a `style.css.map` files under the war’s `styles` directory.
+ * In this configuration, the `styles.scss` file gets compiled to a `main.css`
+ * and a `main.css.map` files under the war’s `styles` directory.
  */
 
 plugins {
@@ -17,4 +17,5 @@ plugins {
 compileSass {
   sourceDir = project.file ("${projectDir}/src/main/styles")
   destPath = "styles"
+  entryPoint("style.scss", "main.css")
 }

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -21,6 +21,10 @@ tasks.compileSass {
     destPath = "styles"
     sourceDir = file("${rootDir}/src/main/styles")
 
+    entryPoint("main.scss", "styles.css")
+    // You can also specify a pair
+    entryPoint("secondary.scss" to "other.css")
+
     loadPath(file("/var/lib/compass"))
 
     style = expanded

--- a/src/functionalTest/java/io/miret/etienne/gradle/sass/SassGradlePluginFunctionalTest.java
+++ b/src/functionalTest/java/io/miret/etienne/gradle/sass/SassGradlePluginFunctionalTest.java
@@ -98,6 +98,51 @@ class SassGradlePluginFunctionalTest {
   }
 
   @Test
+  void should_use_entry_point() throws Exception {
+    GradleRunner.create()
+        .withPluginClasspath()
+        .withArguments("compileEntryPoint")
+        .withProjectDir(projectDir.toFile())
+        .build();
+
+    assertThat(commandHistory()).hasContent(String.format(
+        "sass --style=expanded --source-map-urls=relative %1$s/src/main/sass/main.scss:%1$s/build/sass/style.css",
+        projectDir.toRealPath()
+    ));
+  }
+
+  @Test
+  void should_use_all_entry_points() throws Exception {
+    GradleRunner.create()
+        .withPluginClasspath()
+        .withArguments("compileSeveralEntryPoints")
+        .withProjectDir(projectDir.toFile())
+        .build();
+
+    assertThat(commandHistory()).content()
+        .hasLineCount(1)
+        .startsWith("sass --style=expanded --source-map-urls=relative")
+        .contains(String.format("%1$s/src/main/sass/main.scss:%1$s/build/sass/style.css", projectDir.toRealPath()))
+        .contains(String.format("%1$s/src/main/sass/errors.scss:%1$s/build/sass/errors.css", projectDir.toRealPath()));
+  }
+
+  @Test
+  void should_use_custom_paths() throws Exception {
+    Files.createDirectories(projectDir.resolve("src/main/scss"));
+
+    GradleRunner.create()
+        .withPluginClasspath()
+        .withArguments("compileCustomPaths")
+        .withProjectDir(projectDir.toFile())
+        .build();
+
+    assertThat(commandHistory()).hasContent(String.format(
+        "sass --style=expanded --source-map-urls=relative %1$s/src/main/scss/main.scss:%1$s/build/css/styles/main.css",
+        projectDir.toRealPath()
+    ));
+  }
+
+  @Test
   void should_set_loadPaths () throws IOException {
     GradleRunner.create ()
         .withPluginClasspath ()

--- a/src/functionalTest/resources/io/miret/etienne/gradle/sass/build.gradle
+++ b/src/functionalTest/resources/io/miret/etienne/gradle/sass/build.gradle
@@ -65,3 +65,19 @@ task compileFileSourceMapRelative (type: CompileSass) {
   sourceMap = file
   sourceMapUrls = relative
 }
+
+task compileEntryPoint(type: CompileSass) {
+  entryPoint "main.scss", "style.css"
+}
+
+task compileSeveralEntryPoints(type: CompileSass) {
+  entryPoint "main.scss", "style.css"
+  entryPoint "errors.scss", "errors.css"
+}
+
+task compileCustomPaths(type: CompileSass) {
+  sourceDir = file("src/main/scss")
+  outputDir = file("build/css")
+  destPath = "styles"
+  entryPoint "main.scss", "main.css"
+}

--- a/src/main/java/io/miret/etienne/gradle/sass/CompileSass.java
+++ b/src/main/java/io/miret/etienne/gradle/sass/CompileSass.java
@@ -1,5 +1,6 @@
 package io.miret.etienne.gradle.sass;
 
+import kotlin.Pair;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.tools.ant.taskdefs.condition.Os;
@@ -23,6 +24,8 @@ public class CompileSass extends DefaultTask {
   private final WorkerExecutor workerExecutor;
 
   private final File sassExecutable;
+
+  private final List<Pair<String, String>> entryPoints = new ArrayList<>();
 
   public enum Style {
     expanded,
@@ -48,7 +51,7 @@ public class CompileSass extends DefaultTask {
   @Getter (onMethod_ = {@InputDirectory, @PathSensitive(PathSensitivity.RELATIVE)})
   private File sourceDir = new File (getProject ().getProjectDir (), "src/main/sass");
 
-  private List<File> loadPaths = new ArrayList<> ();
+  private final List<File> loadPaths = new ArrayList<>();
 
   @Setter
   @Getter (onMethod_ = {@Input})
@@ -113,6 +116,14 @@ public class CompileSass extends DefaultTask {
 
   public void loadPath (File loadPath) {
     loadPaths.add (loadPath);
+  }
+
+  public void entryPoint(String from, String to) {
+    entryPoints.add(new Pair<>(from, to));
+  }
+
+  public void entryPoint(Pair<String, String> entryPoint) {
+    entryPoints.add(entryPoint);
   }
 
   public void noCharset () {

--- a/src/main/java/io/miret/etienne/gradle/sass/CompileSass.java
+++ b/src/main/java/io/miret/etienne/gradle/sass/CompileSass.java
@@ -13,10 +13,14 @@ import org.gradle.workers.WorkerExecutor;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 @CacheableTask
 public class CompileSass extends DefaultTask {
@@ -25,6 +29,7 @@ public class CompileSass extends DefaultTask {
 
   private final File sassExecutable;
 
+  @Getter (onMethod_ = @Input)
   private final List<Pair<String, String>> entryPoints = new ArrayList<>();
 
   public enum Style {
@@ -126,6 +131,31 @@ public class CompileSass extends DefaultTask {
     entryPoints.add(entryPoint);
   }
 
+  private Map<File, File> fileEntryPoints() {
+    Path source = sourceDir.toPath();
+    Path output = outputDir.toPath().resolve(destPath);
+    if (entryPoints.isEmpty()) {
+      return Collections.singletonMap(
+          source.toAbsolutePath().normalize().toFile(),
+          output.toAbsolutePath().normalize().toFile()
+      );
+    }
+    return entryPoints.stream()
+        .map(pair -> {
+          Path from = source.resolve(pair.component1());
+          Path to = output.resolve(pair.component2());
+          return new Pair<>(
+              from.toAbsolutePath().normalize().toFile(),
+              to.toAbsolutePath().normalize().toFile());
+        })
+        .collect(toMap(Pair::component1, Pair::component2, (a, b) -> {
+          if (a.equals(b)) {
+            return a;
+          }
+          throw new IllegalStateException("Two different outputs for the same input: " + a + " and " + b + ".");
+        }));
+  }
+
   public void noCharset () {
     charset = false;
   }
@@ -198,8 +228,7 @@ public class CompileSass extends DefaultTask {
     workQueue.submit(CompileSassWorkAction.class, compileSassWorkParameters -> {
       compileSassWorkParameters.getExecutable ().set (sassExecutable);
       compileSassWorkParameters.getLoadPaths ().setFrom (loadPaths);
-      compileSassWorkParameters.getOutputDir ().set (new File (outputDir, destPath));
-      compileSassWorkParameters.getSourceDir ().set (sourceDir);
+      compileSassWorkParameters.getEntryPoints().set(fileEntryPoints());
       compileSassWorkParameters.getStyle ().set (style);
       compileSassWorkParameters.getSourceMap ().set (sourceMap);
       compileSassWorkParameters.getSourceMapUrls ().set (sourceMapUrls);

--- a/src/main/java/io/miret/etienne/gradle/sass/CompileSassWorkAction.java
+++ b/src/main/java/io/miret/etienne/gradle/sass/CompileSassWorkAction.java
@@ -55,7 +55,9 @@ public abstract class CompileSassWorkAction implements WorkAction<CompileSassWor
       if (sourceMap != CompileSass.SourceMap.none) {
         args.add (String.format ("--source-map-urls=%s", parameters.getSourceMapUrls().get()));
       }
-      args.add (String.format ("%s:%s", parameters.getSourceDir().get(), parameters.getOutputDir().get()));
+      parameters.getEntryPoints().get().forEach((from, to) -> {
+        args.add (String.format ("%s:%s", from, to));
+      });
       execSpec.args (args);
     });
   }

--- a/src/main/java/io/miret/etienne/gradle/sass/CompileSassWorkParameters.java
+++ b/src/main/java/io/miret/etienne/gradle/sass/CompileSassWorkParameters.java
@@ -3,15 +3,20 @@ package io.miret.etienne.gradle.sass;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.workers.WorkParameters;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
 
 public interface CompileSassWorkParameters extends WorkParameters {
   RegularFileProperty getExecutable();
   ConfigurableFileCollection getLoadPaths();
 
-  DirectoryProperty getOutputDir();
-  DirectoryProperty getSourceDir();
+  MapProperty<File, File> getEntryPoints();
 
   Property<CompileSass.Style> getStyle();
   Property<CompileSass.SourceMap> getSourceMap();


### PR DESCRIPTION
Resolves #30.

Note that while any file can be specified as entrypoints, input files should lay in `sourceDir` and output files in `outputDir`, otherwise changes to those files won’t be detected by Gradle incremental build.